### PR TITLE
Update mdbook dependency to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased]
+## [Unreleased - 0.3.0]
+
+Updated mdbook to 0.5.2 and pulldown-cmark to 0.13.
 
 ## [0.2.0] - 2024-07-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-image-size"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["George Liu <39660787@qq.com>"]
 license = "MIT"
@@ -10,10 +10,10 @@ description = "A mdbook preprocessor which support image size syntax"
 [dependencies]
 anyhow = "1.0.86"
 clap = "4.5.9"
-mdbook = "0.4.40"
+mdbook-preprocessor = "0.5.2"
 serde_json = "1.0.120"
 semver = "1.0.23"
-pulldown-cmark = "0.11.0"
+pulldown-cmark = "0.13.0"
 regex = "1.10.5"
 once_cell = "1.19.0"
 

--- a/src/bin/mdbook-image-size.rs
+++ b/src/bin/mdbook-image-size.rs
@@ -1,7 +1,7 @@
 use clap::{Arg, ArgMatches, Command};
-use mdbook::errors::Error;
-use mdbook::preprocess::{CmdPreprocessor, Preprocessor};
 use mdbook_image_size::ImageSize;
+use mdbook_preprocessor::errors::Error;
+use mdbook_preprocessor::Preprocessor;
 use semver::{Version, VersionReq};
 use std::io;
 use std::process;
@@ -31,17 +31,17 @@ fn main() {
 }
 
 fn handle_preprocessing(pre: &dyn Preprocessor) -> Result<(), Error> {
-    let (ctx, book) = CmdPreprocessor::parse_input(io::stdin())?;
+    let (ctx, book) = mdbook_preprocessor::parse_input(io::stdin())?;
 
     let book_version = Version::parse(&ctx.mdbook_version)?;
-    let version_req = VersionReq::parse(mdbook::MDBOOK_VERSION)?;
+    let version_req = VersionReq::parse(mdbook_preprocessor::MDBOOK_VERSION)?;
 
     if !version_req.matches(&book_version) {
         eprintln!(
             "Warning: The {} plugin was built against version {} of mdbook, \
              but we're being called from version {}",
             pre.name(),
-            mdbook::MDBOOK_VERSION,
+            mdbook_preprocessor::MDBOOK_VERSION,
             ctx.mdbook_version
         );
     }
@@ -59,7 +59,7 @@ fn handle_supports(pre: &dyn Preprocessor, sub_args: &ArgMatches) -> ! {
     let supported = pre.supports_renderer(renderer);
 
     // Signal whether the renderer is supported by exiting with 1 or 0.
-    if supported {
+    if supported.is_ok_and(|supported| supported) {
         process::exit(0);
     } else {
         process::exit(1);

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::types::State;
-use mdbook::errors::Result as MdbookResult;
+use mdbook_preprocessor::errors::Result as MdbookResult;
 use once_cell::sync::Lazy;
 use pulldown_cmark::{CowStr, Event, Parser};
 use regex::{Captures, Regex};

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -1,6 +1,6 @@
-use mdbook::book::Book;
-use mdbook::errors::Error;
-use mdbook::preprocess::{Preprocessor, PreprocessorContext};
+use mdbook_preprocessor::book::{Book, BookItem};
+use mdbook_preprocessor::errors::{Error, Result as MdbookResult};
+use mdbook_preprocessor::{Preprocessor, PreprocessorContext};
 
 use crate::markdown::preprocess;
 
@@ -21,7 +21,7 @@ impl Preprocessor for ImageSize {
 
     fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {
         book.for_each_mut(|item| {
-            if let mdbook::BookItem::Chapter(chapter) = item {
+            if let BookItem::Chapter(chapter) = item {
                 let _ = preprocess(&chapter.content).map(|c| {
                     chapter.content = c;
                 });
@@ -31,7 +31,7 @@ impl Preprocessor for ImageSize {
         Ok(book)
     }
 
-    fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer != "not-supported"
+    fn supports_renderer(&self, renderer: &str) -> MdbookResult<bool> {
+        Ok(renderer != "not-supported")
     }
 }


### PR DESCRIPTION
Without this update, the plugin crashes on mdbook 0.5.x.

Followed the migration guide here: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#05-migration-guide

Thanks for creating this plugin!